### PR TITLE
Update ByteBukkit Integrations and fix some labeling

### DIFF
--- a/src/components/views/WorkshopView.tsx
+++ b/src/components/views/WorkshopView.tsx
@@ -63,7 +63,7 @@ interface RegistryPackage {
   file_name?: string;
   file_size?: number;
   server_address?: string;
-  server_homepage?: string;
+  server_discord?: string;
   server_type?: string;
 }
 
@@ -72,7 +72,7 @@ interface ServerListing {
   server_type: string;
   server_address: string;
   server_owner: string;
-  server_homepage?: string;
+  server_discord?: string;
   console_version: string;
   server_icon: string;
 }

--- a/src/components/views/WorkshopView.tsx
+++ b/src/components/views/WorkshopView.tsx
@@ -1115,20 +1115,11 @@ function PackageModal({
 
           <div className="flex flex-col p-6 gap-6 overflow-y-auto flex-1">
             <div className="space-y-4">
-              <div className="space-y-2">
-                <span className="text-[10px] text-[#666] mc-text-shadow uppercase tracking-[0.2em] font-bold">
-                  Project Description
-                </span>
-                <p className="text-sm text-[#C0C0C0] mc-text-shadow leading-relaxed italic opacity-90">
-                  {pkg.description}
-                </p>
-              </div>
-
               {pkg.extended_description &&
                 pkg.extended_description.trim() !== "" && (
                   <div className="space-y-2 bg-black/20 p-4 border border-[#333] rounded-sm">
                     <span className="text-[10px] text-[#555] mc-text-shadow uppercase tracking-[0.2em] font-bold">
-                      Additional Resources
+                      Plugin Description
                     </span>
                     <div className="text-sm text-[#A0A0A0] mc-text-shadow leading-relaxed workshop-markdown">
                       <ReactMarkdown remarkPlugins={[remarkGfm]}>
@@ -1217,7 +1208,7 @@ function PackageModal({
                       </div>
                       <div className="flex justify-between text-xs">
                         <span className="text-[#888] mc-text-shadow">
-                          Game Version:
+                          Server Type:
                         </span>
                         <span className="text-[#55FF55] mc-text-shadow">
                           {pkg.game_version || "N/A"}

--- a/src/components/views/WorkshopView.tsx
+++ b/src/components/views/WorkshopView.tsx
@@ -197,7 +197,7 @@ const WorkshopView = memo(function WorkshopView() {
             name: s.server_name,
             author: s.server_owner,
             description: s.server_address,
-            extended_description: `**Type:** ${s.server_type}\n**Console:** ${s.console_version}\n**Owner:** ${s.server_owner}`,
+            extended_description: `**Server:** ${s.server_type}\n**Version:** ${s.console_version}\n**Owner:** ${s.server_owner}`,
             category: [s.server_type],
             thumbnail: `${SERVERS_BASE}${s.server_icon}`,
             version: s.console_version,


### PR DESCRIPTION
**List of things fixed:**

- Server List Expanded Views updated for the `server_homepage` -> `server_discord` change
- Plugin view removed short description and fixed labelling for the big description `Additional Resources` -> `Plugin Description`
- Changed `Game Version` to `Server Type` as it being wrongly labelled somehow

These changes occured due to changes on the [ByteBukkit](https://bytebukkit.github.io) backend.
_**Affected Files:**_ `WorkshopView.tsx`