### PR TITLE
fix(lceonline): user turning null by refreshing token when app is opened

### DIFF
--- a/src/services/LceOnlineService.ts
+++ b/src/services/LceOnlineService.ts
@@ -23,6 +23,9 @@ export class LceOnlineService {
   private _listeners: Array<() => void> = [];
   constructor() {
     this.loadSession();
+    if (this._session) {
+      this.refreshToken();
+    }
   }
 
   onSessionChange(listener: () => void): () => void {
@@ -193,6 +196,28 @@ export class LceOnlineService {
     }
 
     return data;
+  }
+
+  async refreshToken(): Promise<boolean> {
+    if (!this._session) return false;
+
+    try {
+      const res = await this.request<string>("POST", "/refreshtoken", null, AUTH_BASE_URL);
+      if (typeof res === "string" && res.startsWith("-")) {
+        const [username, token] = res.slice(1).split(":");
+        this._session.accessToken = token;
+        this._session.account = { username, displayName: username };
+        this.saveSession();
+        this._notify();
+        return true;
+      }
+      this.logoutLocal();
+      return false;
+    } catch (e) {
+      console.warn("Failed to refresh token", e);
+      this.logoutLocal()
+      return false;
+    }
   }
 
   async getSocialLists(): Promise<{


### PR DESCRIPTION
If a user opens the app after awhile they can get turned into a "null" this partly fixes that but this will still happen if someone logs into the LCEOnline client.