### PR TITLE
fix(security): restrict workshop api cors to specific origins

### DIFF
--- a/src-tauri/src/workshop_server.rs
+++ b/src-tauri/src/workshop_server.rs
@@ -92,7 +92,10 @@ async fn handle(stream: tokio::net::TcpStream) {
                     "application/octet-stream"
                 };
                 let response = format!(
-                    "HTTP/1.1 200 OK\r\nContent-Type: {}\r\nContent-Length: {}\r\nAccess-Control-Allow-Origin: *\r\nConnection: close\r\n\r\n",
+                    // security: scope CORS to the tauri webview origin. was
+                    // "*" which let any website the user visits fetch the
+                    // workshop server. (LCEL-07)
+                    "HTTP/1.1 200 OK\r\nContent-Type: {}\r\nContent-Length: {}\r\nAccess-Control-Allow-Origin: http://localhost:1420\r\nConnection: close\r\n\r\n",
                     content_type,
                     body.len(),
                 );


### PR DESCRIPTION
the workshop HTTP server had Access-Control-Allow-Origin set to * which lets any website make requests to the local workshop API. a malicious site could enumerate installed mods or trigger downloads.

changed the CORS header to only allow the origins the launcher actually serves.