### PR TITLE
Replace Moon Edition download link with permanent tag link

### DIFF
--- a/src/hooks/useGameManager.ts
+++ b/src/hooks/useGameManager.ts
@@ -71,7 +71,7 @@ export const BASE_EDITIONS = [
     id: "moon_edition",
     name: "Minecraft: Moon Edition",
     desc: "Galacticraft LCE port (Modded build!)",
-    url: "https://github.com/blazin-blaze/moon-edition/releases/download/v1.0.1/moonEditionWindows64.zip",
+    url: "https://github.com/blazin-blaze/moon-edition/releases/download/launcher/moonEditionWindows64.zip",
     titleImage: "/images/minecraft_title_moon.png",
     supportsSlimSkins: false,
     logo: "/images/moonEdition.png",


### PR DESCRIPTION
The current download link being used is only for the v1.0.1 version of Moon Edition.

To accommodate new updates, I have made a new tag for Moon Edition - launcher - that will always be updated with the latest edition, not just one particular edition.

I am submitting this PR to change the download link to use the new release tag.

Apologies for not having made a proper permanent tag beforehand. :)