### PR TITLE
fix(rpc): discord rpc proper shutdown when launcher closes

### DIFF
--- a/src/context/LauncherContext.tsx
+++ b/src/context/LauncherContext.tsx
@@ -165,7 +165,6 @@ export function LauncherProvider({ children }: { children: React.ReactNode }) {
         const unlistenClose = await listen("tauri://close-requested", async () => {
           setIsWindowVisible(false);
           if (config.rpcEnabled) {
-            // the launcher never
             await RpcService.StopRPC();
           }
         });

--- a/src/context/LauncherContext.tsx
+++ b/src/context/LauncherContext.tsx
@@ -7,6 +7,7 @@ import { useSkinSync } from "../hooks/useSkinSync";
 import { useDiscordRPC } from "../hooks/useDiscordRPC";
 import { useGamepad } from "../hooks/useGamepad";
 import { useUpdateCheck } from "../hooks/useUpdateCheck";
+import RpcService from "../services/RpcService";
 
 interface UIContextType {
   activeView: string;
@@ -161,8 +162,12 @@ export function LauncherProvider({ children }: { children: React.ReactNode }) {
     const setupVisibilityDetection = async () => {
       try {
         const { listen } = await import("@tauri-apps/api/event");
-        const unlistenClose = await listen("tauri://close-requested", () => {
+        const unlistenClose = await listen("tauri://close-requested", async () => {
           setIsWindowVisible(false);
+          if (config.rpcEnabled) {
+            // the launcher never
+            await RpcService.StopRPC();
+          }
         });
 
         const unlistenShow = await listen("tauri://window-shown", () => {
@@ -190,7 +195,7 @@ export function LauncherProvider({ children }: { children: React.ReactNode }) {
     };
 
     setupVisibilityDetection();
-  }, []);
+  }, [config.rpcEnabled]);
 
   const uiValue = useMemo(() => ({
     activeView, setActiveView, showIntro, setShowIntro,

--- a/src/services/RpcService.ts
+++ b/src/services/RpcService.ts
@@ -1,4 +1,4 @@
-import { setActivity, start } from "tauri-plugin-drpc";
+import { setActivity, start, clearActivity, stop } from "tauri-plugin-drpc";
 import {
   Activity,
   ActivityType,
@@ -71,6 +71,19 @@ class RPC {
     } catch (e) {
       console.error("Failed to set RPC activity:", e);
     }
+  }
+
+  public async StopRPC() {
+      try {
+        await clearActivity();
+        await stop();
+      } catch (e) {
+        // no need to handle errors here as the launcher will close anyways!
+      } finally {
+        this.initialized = false;
+        this.initializationPromise = null;
+        sessionStorage.removeItem("lce_rpc_started");
+      }
   }
 }
 


### PR DESCRIPTION
Issue #177 

Discord Rich Presence was not being properly cleared when the launcher was closed, sometimes if the process was not shut down properly it would remain stuck in discord status as if you were still playing or had the launcher still opened. It did not happen when the launcher was properly closed though.